### PR TITLE
fix: create and gain permission for `.moonraker_database`

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,6 +5,7 @@ cd ~ || exit 1
 [ ! -d ~/klipper_config ] && mkdir klipper_config
 [ ! -d ~/klipper_logs ] && mkdir klipper_logs
 [ ! -d ~/gcode_files ] && mkdir gcode_files
+[ ! -d ~/.moonraker_database ] && mkdir .moonraker_database
 
 [ ! -f ~/klipper_config/printer.cfg ] && \
 cp ~/example-configs/printer.cfg ~/klipper_config/printer.cfg
@@ -14,6 +15,7 @@ cp ~/example-configs/moonraker.conf ~/klipper_config/moonraker.conf
 sudo chown -R printer:printer ~/klipper_config
 sudo chown -R printer:printer ~/klipper_logs
 sudo chown -R printer:printer ~/gcode_files
+sudo chown -R printer:printer ~/.moonraker_database
 
 sudo -S rm /bin/systemctl
 sudo -S ln -s /bin/service_control /bin/systemctl


### PR DESCRIPTION
When deleting the .moonraker_database on the host system, e.g. for wanting to start with a fresh database, Moonraker throws a permission denied error on restart of the container and is therefor not able to recreate new database files which in turn will prevent Moonraker from starting. This PR fixes that issue.


Signed-off-by: Dominik Willner <th33xitus@gmail.com>