### PR TITLE
chore: remove maintained tag from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![License](https://img.shields.io/github/license/mainsail-crew/virtual-klipper-printer.svg)](https://github.com/mainsail-crew/virtual-klipper-printer/blob/master/LICENSE 'License')
-[![Project Maintenance](https://img.shields.io/maintenance/yes/2022.svg)](https://github.com/mainsail-crew/virtual-klipper-printer 'GitHub Repository')
 ---
 # Virtual-Klipper-Printer
 


### PR DESCRIPTION
This PR remove the maintained tag from the README.md, because it doesn't update itself.