### PR TITLE
refactor: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea
-/printer_data
+/printer_data*


### PR DESCRIPTION
ignores any folder starting with `printer_data`