### PR TITLE
fix: add .gitattributes to force bash scripts to have LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force bash scripts to always have LF line endings
+
+*.sh eol=LF


### PR DESCRIPTION
Fixes #34 

In the latest commit, the `start.sh` file has Windows line endings and that messes with Bash under Linux so the container will not start.

This PR fixes this by:
1. Correcting the line endings to `LF` in the `start.sh` file
2. Adding a `.gitattributes` file that forces `LF` line endings on all bash scripts.

This should ensure that even if the files are edited in a Windows editor (such as VS Code) that line endings will be correctly preserved.