### PR TITLE
chore: add fallback KLIPPER_REPO url in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /build
 
 ### Prepare our applications
 #### Klipper
-ARG KLIPPER_REPO
+ARG KLIPPER_REPO=https://github.com/Klipper3d/klipper.git
 ENV KLIPPER_REPO=${KLIPPER_REPO}
 RUN git clone ${KLIPPER_REPO} klipper \
     && virtualenv -p python3 /build/klippy-env \


### PR DESCRIPTION
This PR adds a fallback KLIPPER_REPO url in the Dockerfile. With this PR, you can execute `docker build --no-cache -t <name> .` without an issue.