### PR TITLE
fix: mjpg streamer does not start streaming

### DIFF
--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -46,7 +46,7 @@ autorestart=true
 redirect_stderr=true
 
 [program:webcamd]
-command=/home/printer/mjpg-streamer/mjpg_streamer -i "input_file.so -e -d 0.8 -f /home/printer/webcam_images" -o "output_http.so -w /home/printer/mjpg-streamer/www"
+command=/home/printer/mjpg-streamer/mjpg_streamer -i "input_file.so -e -d 0.8 -f /home/printer/mjpg_streamer_images" -o "output_http.so -w /home/printer/mjpg-streamer/www"
 user=printer
 process_name=webcamd
 directory=/home/printer


### PR DESCRIPTION
* The image path is mjpg_streamer_images, but the mjpg_streamer startup command uses webcam_images, which causes mjpg_streamer to fail to start.

* Another solution is to modify the Dockerfile's 
    `COPY ./mjpg_streamer_images/ ./mjpg_streamer_images/`  to 
    `COPY ./mjpg_streamer_images/ ./webcam_images/`.