### PR TITLE
fix: fix Simulavr git path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN git clone ${KLIPPER_REPO} klipper \
 
 #### Simulavr
 COPY config/simulavr.config /usr/src
-RUN git clone -b master https://git.savannah.nongnu.org/git/simulavr.git \
+RUN git clone -b master git://git.savannah.gnu.org/simulavr.git \
     # Build the firmware
     && cd klipper \
     && cp /usr/src/simulavr.config .config \


### PR DESCRIPTION
This PR update the URL to the GIT repository from Simulavr.

Fix #44 and #45