### PR TITLE
fix: remove uid & gid for tmpfs mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
     networks:
       - dev_net
     tmpfs:
-      - /tmp:noexec,mode=1777
-      - /home/printer/printer_data/comms:noexec,uid=1000,gid=1000,mode=0755
+      - /tmp:noexec
+      - /home/printer/printer_data/comms:noexec
 networks:
   dev_net:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       args:
         KLIPPER_REPO: ${KLIPPER_REPO:-https://github.com/Klipper3d/klipper.git}
     volumes:
-      - ./printer_data:/home/printer/printer_data:delegated
+      - ./printer_data:/home/printer/printer_data:delegated,Z
     ports:
       - "7125:7125"
       - "8110:8080"


### PR DESCRIPTION
This PR just remove the UID and GID in the tmpfs mounts. This should fix the start on Windows host systems.