### PR TITLE
fix: fix userrights for printer_data/comms

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -28,7 +28,7 @@ function status_msg() {
 }
 
 ######
-# Test if all requierd folders exist if not create them and
+# Test if all required folders exist if not create them and
 # test for correct ownership of all required folders
 ###
 function check_folder_perms_and_create() {

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -14,6 +14,7 @@ set -e
 
 REQUIRED_FOLDERS=(
   "${HOME}/printer_data"
+  "${HOME}/printer_data/comms"
   "${HOME}/printer_data/config"
   "${HOME}/printer_data/logs"
   "${HOME}/printer_data/gcodes"


### PR DESCRIPTION
This PR add the directory `~/printer_data/comms` to `REQUIRED_FOLDERS` in the start.sh file. This folders are checked while starting the container and fix the owner.